### PR TITLE
マジックリンクのみでサインアップ、ログインを出来るページを追加

### DIFF
--- a/src/app/login/magiclink/page.tsx
+++ b/src/app/login/magiclink/page.tsx
@@ -1,0 +1,80 @@
+import { createClient } from '@/utils/supabase/server';
+import { headers } from 'next/headers';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { SubmitButton } from '../submit-button';
+
+export default function LoginMagicLinkPage({
+  searchParams,
+}: {
+  searchParams: { message: string };
+}) {
+  const signIn = async (formData: FormData) => {
+    'use server';
+
+    const email = formData.get('email') as string;
+    const supabase = createClient();
+
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${headers().get('origin')}/auth/callback`,
+      },
+    });
+
+    if (error) {
+      return redirect('/login/magiclink?message=Could not authenticate user');
+    }
+
+    return redirect('/login/magiclink?message=Check email to continue sign in process');
+  };
+
+  return (
+    <div className="flex-1 flex flex-col w-full px-8 sm:max-w-md justify-center gap-2">
+      <Link
+        href="/"
+        className="absolute left-8 top-8 py-2 px-4 rounded-md no-underline text-foreground bg-btn-background hover:bg-btn-background-hover flex items-center group text-sm"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="mr-2 h-4 w-4 transition-transform group-hover:-translate-x-1"
+          role="img"
+          aria-label="Back"
+        >
+          <polyline points="15 18 9 12 15 6" />
+        </svg>{' '}
+        Back
+      </Link>
+
+      <form className="animate-in flex-1 flex flex-col w-full justify-center gap-2 text-foreground">
+        <label className="text-md" htmlFor="email">
+          Email
+        </label>
+        <input
+          className="rounded-md px-4 py-2 bg-inherit border mb-6"
+          name="email"
+          placeholder="you@example.com"
+          required
+        />
+        <SubmitButton
+          formAction={signIn}
+          className="bg-green-700 rounded-md px-4 py-2 text-foreground mb-2"
+          pendingText="Process is running..."
+        >
+          Sign Up or Sign In
+        </SubmitButton>
+        {searchParams?.message && (
+          <p className="mt-4 p-4 bg-foreground/10 text-foreground text-center">{searchParams.message}</p>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -30,11 +30,19 @@ export default async function AuthButton() {
       </form>
     </div>
   ) : (
-    <Link
-      href="/login"
-      className="py-2 px-3 flex rounded-md no-underline bg-btn-background hover:bg-btn-background-hover"
-    >
-      Login
-    </Link>
+    <>
+      <Link
+        href="/login"
+        className="py-2 px-3 flex rounded-md no-underline bg-btn-background hover:bg-btn-background-hover"
+      >
+        Login
+      </Link>
+      <Link
+        href="/login/magiclink"
+        className="py-2 px-3 flex rounded-md no-underline bg-btn-background hover:bg-btn-background-hover"
+      >
+        Magic Link Login
+      </Link>
+    </>
   );
 }


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/supabase-private-platform-example/issues/2

# この PR で対応する範囲 / この PR で対応しない範囲

パスワードなしでサインアップ、ログインを出来る機能を追加する。

# Storybook の URL、 スクリーンショット

<img width="615" alt="MagicLinkLogin" src="https://github.com/nekochans/supabase-private-platform-example/assets/11032365/f6a47d75-644a-4869-8e0c-7193734f8063">

# 変更点概要

パスワードログインはセキュリティ的に問題があり、パスワード忘れのフロー等も考慮する必要があるのでメールアドレスに認証URLを送信して、認証URLを踏んだらログインする機能を追加。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

以下にも説明を記載済。

https://zenn.dev/link/comments/430931c90982f5