### PR TITLE
VercelとSupabaseの連携設定を追加

### DIFF
--- a/src/app/_components/NewPasswordForm.tsx
+++ b/src/app/_components/NewPasswordForm.tsx
@@ -4,10 +4,10 @@ import { SubmitButton } from '@/app/login/submit-button';
 import { type FormEvent, useEffect, useState } from 'react';
 
 type Props = {
-  origin: string;
+  appUrl: string;
 };
 
-export const NewPasswordForm = ({ origin }: Props) => {
+export const NewPasswordForm = ({ appUrl }: Props) => {
   const [refreshToken, setRefreshToken] = useState<string>('');
 
   useEffect(() => {
@@ -27,7 +27,7 @@ export const NewPasswordForm = ({ origin }: Props) => {
     const password = new FormData(event.currentTarget).get('password') as string;
 
     if (password !== '' && refreshToken !== '') {
-      const createPasswordResponse = await fetch(`${origin}/auth/password`, {
+      const createPasswordResponse = await fetch(`${appUrl}/auth/password`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -47,7 +47,7 @@ export const NewPasswordForm = ({ origin }: Props) => {
 
       const email = createPasswordResponseBody.user?.email;
       if (email != null && typeof window !== 'undefined') {
-        const loginResponse = await fetch(`${origin}/auth/login`, {
+        const loginResponse = await fetch(`${appUrl}/auth/login`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -58,7 +58,7 @@ export const NewPasswordForm = ({ origin }: Props) => {
         const responseBody = (await loginResponse.json()) as { loginSuccess: boolean; errorMessage?: string };
 
         if (responseBody.loginSuccess) {
-          window.location.href = `${origin}/protected`;
+          window.location.href = `${appUrl}/protected`;
         }
         // TODO ログイン失敗時のエラーハンドリングを考える
       }

--- a/src/app/_components/NewPasswordForm.tsx
+++ b/src/app/_components/NewPasswordForm.tsx
@@ -3,7 +3,11 @@
 import { SubmitButton } from '@/app/login/submit-button';
 import { type FormEvent, useEffect, useState } from 'react';
 
-export const NewPasswordForm = () => {
+type Props = {
+  origin: string;
+};
+
+export const NewPasswordForm = ({ origin }: Props) => {
   const [refreshToken, setRefreshToken] = useState<string>('');
 
   useEffect(() => {
@@ -23,7 +27,7 @@ export const NewPasswordForm = () => {
     const password = new FormData(event.currentTarget).get('password') as string;
 
     if (password !== '' && refreshToken !== '') {
-      const createPasswordResponse = await fetch('http://localhost:24000/auth/password', {
+      const createPasswordResponse = await fetch(`${origin}/auth/password`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -43,7 +47,7 @@ export const NewPasswordForm = () => {
 
       const email = createPasswordResponseBody.user?.email;
       if (email != null && typeof window !== 'undefined') {
-        const loginResponse = await fetch('http://localhost:24000/auth/login', {
+        const loginResponse = await fetch(`${origin}/auth/login`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -54,7 +58,7 @@ export const NewPasswordForm = () => {
         const responseBody = (await loginResponse.json()) as { loginSuccess: boolean; errorMessage?: string };
 
         if (responseBody.loginSuccess) {
-          window.location.href = 'http://localhost:24000/protected';
+          window.location.href = `${origin}/protected`;
         }
         // TODO ログイン失敗時のエラーハンドリングを考える
       }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,9 @@ import DeployButton from '@/components/DeployButton';
 import Header from '@/components/Header';
 import ConnectSupabaseSteps from '@/components/tutorial/ConnectSupabaseSteps';
 import SignUpUserSteps from '@/components/tutorial/SignUpUserSteps';
+import { localHostUrl } from '@/features/url';
 import { createClient } from '@/utils/supabase/server';
+import { headers } from 'next/headers';
 
 export default async function Index() {
   const canInitSupabaseClient = () => {
@@ -20,6 +22,8 @@ export default async function Index() {
 
   const isSupabaseConnected = canInitSupabaseClient();
 
+  const origin = headers().get('origin') ?? localHostUrl();
+
   return (
     <div className="flex-1 w-full flex flex-col gap-20 items-center">
       <nav className="w-full flex justify-center border-b border-b-foreground/10 h-16">
@@ -29,7 +33,7 @@ export default async function Index() {
         </div>
       </nav>
 
-      <NewPasswordForm />
+      <NewPasswordForm origin={origin} />
 
       <div className="animate-in flex-1 flex flex-col gap-20 opacity-0 max-w-4xl px-3">
         <Header />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,9 +4,8 @@ import DeployButton from '@/components/DeployButton';
 import Header from '@/components/Header';
 import ConnectSupabaseSteps from '@/components/tutorial/ConnectSupabaseSteps';
 import SignUpUserSteps from '@/components/tutorial/SignUpUserSteps';
-import { localHostUrl } from '@/features/url';
+import { appUrl } from '@/features/url';
 import { createClient } from '@/utils/supabase/server';
-import { headers } from 'next/headers';
 
 export default async function Index() {
   const canInitSupabaseClient = () => {
@@ -22,8 +21,6 @@ export default async function Index() {
 
   const isSupabaseConnected = canInitSupabaseClient();
 
-  const origin = headers().get('origin') ?? localHostUrl();
-
   return (
     <div className="flex-1 w-full flex flex-col gap-20 items-center">
       <nav className="w-full flex justify-center border-b border-b-foreground/10 h-16">
@@ -33,7 +30,7 @@ export default async function Index() {
         </div>
       </nav>
 
-      <NewPasswordForm origin={origin} />
+      <NewPasswordForm appUrl={appUrl()} />
 
       <div className="animate-in flex-1 flex flex-col gap-20 opacity-0 max-w-4xl px-3">
         <Header />

--- a/src/features/url.ts
+++ b/src/features/url.ts
@@ -1,3 +1,7 @@
-export const localHostUrl = (): string => {
+export const appUrl = (): string => {
+  if (process.env.NEXT_PUBLIC_VERCEL_URL) {
+    return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`;
+  }
+
   return 'http://localhost:24000';
 };

--- a/src/features/url.ts
+++ b/src/features/url.ts
@@ -1,0 +1,3 @@
+export const localHostUrl = (): string => {
+  return 'http://localhost:24000';
+};


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/supabase-private-platform-example/issues/4

# この PR で対応する範囲 / この PR で対応しない範囲

Supabaseの接続に必要な環境変数をVercel側に同期させてVercelのプレビュー環境でSupabaseの認証機能を利用出来るようにする。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

SupabaseとVercelの連携機能を利用してVercelのプレビュー環境でSupabaseの認証機能を利用出来るように改修。

具体的な手順に関しては以下のコメントに残してある。

https://zenn.dev/link/comments/90d95bfba94cf4

https://zenn.dev/link/comments/072c53e496a4e3

ソーシャルログインの場合は認証プロバイダ側にVercelのプレビュー環境のURLをリダイレクトURIとして登録する必要があるので、その部分を自動化するのは結構難しそう、仮に出来たとしてもURLの登録数上限等もあるので実運用するのは現実的ではないと判断している。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし