### PR TITLE
Migration前に db lint と --dry-run を実行するように変更

### DIFF
--- a/.github/workflows/dev-supabase-db-migrate.yml
+++ b/.github/workflows/dev-supabase-db-migrate.yml
@@ -7,7 +7,17 @@ on:
       - main
 
 jobs:
+  lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 1.169.8
+      - run: supabase db start
+      - run: supabase db lint
   migrate:
+    needs: lint
     runs-on: ubuntu-22.04
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.DEV_SUPABASE_ACCESS_TOKEN }}
@@ -19,4 +29,5 @@ jobs:
         with:
           version: 1.169.8
       - run: supabase link --project-ref $SUPABASE_PROJECT_ID
+      - run: supabase db push --dry-run
       - run: supabase db push


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/supabase-private-platform-example/issues/6

# この PR で対応する範囲 / この PR で対応しない範囲

Migration前に db lint と --dry-run を実行するように変更する。

# Storybook の URL、 スクリーンショット

なし

# 変更点概要

タイトルの通り、もしも問題があった場合早めに気がつけるようにしたいので、db lint と --dry-run を実行するように変更。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし