### PR TITLE
Vercel上でDBのMigrationを実施するように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ http://127.0.0.1:54324
 npm run supabase:stop
 ```
 
-## SupabaseのMigration実行
+## SupabaseのMigration実行（ローカル環境）
 
 以下でMigrationを実行します。
 
@@ -86,6 +86,33 @@ npm run supabase:db:reset
 ```
 
 このコマンドは一度DBをリセットしてからMigrationを実行するのでローカル開発環境のデータが消えてしまう点にご注意ください。
+
+## SupabaseのMigration実行（開発、本番環境）
+
+Vercelで運用されているので、Vercel上で以下のnpm scriptが実行されるようになっています。
+
+- `supabase:login`
+- `supabase:link`
+- `supabase:db:push`
+- `vercel:build`
+
+以下の環境変数を設定する事でローカルからでも本番環境のSupabaseプロジェクトへのMigrationが可能です。
+
+しかし誤って本番環境のデータを破壊してしまうリスクがある為、緊急時以外の利用は非推奨となります。
+
+- `SUPABASE_PROJECT_ID`
+- `SUPABASE_ACCESS_TOKEN`
+- `SUPABASE_DB_PASSWORD`
+
+以下のトリガーで実行されます。（Vercelへのデプロイタイミングと同時です）
+
+### 開発環境用SupabaseプロジェクトへのMigration
+
+`main` Branch以外へのPushが行われた場合に実行されます。
+
+### 本番環境用SupabaseプロジェクトへのMigration
+
+`main` BranchへのPushが行われた場合に実行されます。
 
 ## SupabaseのMigrationファイル作成
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "supabase:stop": "supabase stop",
     "supabase:status": "supabase status",
     "supabase:db:reset": "supabase db reset",
-    "supabase:migration:new": "supabase migration new"
+    "supabase:migration:new": "supabase migration new",
+    "supabase:login": "supabase login --token $SUPABASE_ACCESS_TOKEN",
+    "supabase:link": "supabase link --project-ref $SUPABASE_PROJECT_ID",
+    "supabase:db:push:dry-run": "supabase db push --dry-run",
+    "supabase:db:push": "supabase db push",
+    "vercel:build": "npm run supabase:start && npm run supabase:login && npm run supabase:link && npm run supabase:db:push:dry-run && npm run build && npm run supabase:db:push"
   },
   "dependencies": {
     "@supabase/ssr": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "supabase:link": "supabase link --project-ref $SUPABASE_PROJECT_ID",
     "supabase:db:push:dry-run": "supabase db push --dry-run",
     "supabase:db:push": "supabase db push",
-    "vercel:build": "npm run supabase:start && npm run supabase:login && npm run supabase:link && npm run supabase:db:push:dry-run && npm run build && npm run supabase:db:push"
+    "vercel:build": "npm run supabase:login && npm run supabase:link && npm run supabase:db:push:dry-run && npm run build && npm run supabase:db:push"
   },
   "dependencies": {
     "@supabase/ssr": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "supabase:login": "supabase login --token $SUPABASE_ACCESS_TOKEN",
     "supabase:link": "supabase link --project-ref $SUPABASE_PROJECT_ID",
     "supabase:db:push": "supabase db push",
-    "supabase:db:push:dry-run": "supabase db push --dry-run",
-    "vercel:build": "npm run supabase:login && npm run supabase:link && npm run supabase:db:push:dry-run && npm run build && npm run supabase:db:push"
+    "vercel:build": "npm run supabase:login && npm run supabase:link && npm run build && npm run supabase:db:push"
   },
   "dependencies": {
     "@supabase/ssr": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "supabase:login": "supabase login --token $SUPABASE_ACCESS_TOKEN",
     "supabase:link": "supabase link --project-ref $SUPABASE_PROJECT_ID",
     "supabase:db:push": "supabase db push",
-    "vercel:build": "npm run supabase:login && npm run supabase:link && npm run build && npm run supabase:db:push"
+    "supabase:db:push:dry-run": "supabase db push --dry-run",
+    "vercel:build": "npm run supabase:login && npm run supabase:link && npm run supabase:db:push:dry-run && npm run build && npm run supabase:db:push"
   },
   "dependencies": {
     "@supabase/ssr": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
     "supabase:migration:new": "supabase migration new",
     "supabase:login": "supabase login --token $SUPABASE_ACCESS_TOKEN",
     "supabase:link": "supabase link --project-ref $SUPABASE_PROJECT_ID",
-    "supabase:db:push:dry-run": "supabase db push --dry-run",
     "supabase:db:push": "supabase db push",
-    "vercel:build": "npm run supabase:login && npm run supabase:link && npm run supabase:db:push:dry-run && npm run build && npm run supabase:db:push"
+    "vercel:build": "npm run supabase:login && npm run supabase:link && npm run build && npm run supabase:db:push"
   },
   "dependencies": {
     "@supabase/ssr": "0.3.0",

--- a/supabase/migrations/20240602071050_create_test.sql
+++ b/supabase/migrations/20240602071050_create_test.sql
@@ -1,0 +1,8 @@
+CREATE TABLE tests(
+    id UUID DEFAULT gen_random_uuid(),
+    supabase_user_id NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (ids),
+    UNIQUE (user_id)
+);

--- a/supabase/migrations/20240602071050_create_test.sql
+++ b/supabase/migrations/20240602071050_create_test.sql
@@ -1,8 +1,0 @@
-CREATE TABLE tests(
-    id UUID DEFAULT gen_random_uuid(),
-    supabase_user_id NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (ids),
-    UNIQUE (user_id)
-);


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/supabase-private-platform-example/issues/6

# この PR で対応する範囲 / この PR で対応しない範囲

DBのMigrationをVercelデプロイと同タイミングで実施するように変更。

# Storybook の URL、 スクリーンショット

UI変更はないのでなし

# 変更点概要

Supabase CLIのGitHubActionsを利用してMigrationを実行する形だとMigrationだけ成功してVercelデプロイが失敗（その逆もありえる）という事が起こってしまう可能性があるのでVercelのビルドステップ時にDBのMigrationを実施するように変更。

以下の環境変数をVercel上に登録する事でMigrationの実行が無事実現出来た。

- `SUPABASE_PROJECT_ID`
- `SUPABASE_ACCESS_TOKEN`
- `SUPABASE_DB_PASSWORD`

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし