### PR TITLE
Migrationが実行されるか最終確認する為にテーブルを追加

### DIFF
--- a/supabase/migrations/20240602091313_create_table_accounts.sql
+++ b/supabase/migrations/20240602091313_create_table_accounts.sql
@@ -1,0 +1,8 @@
+CREATE TABLE accounts(
+    id UUID DEFAULT gen_random_uuid(),
+    supabase_user_id UUID NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE (supabase_user_id)
+);

--- a/supabase/migrations/20240602091422_create_triggers_on_accounts.sql
+++ b/supabase/migrations/20240602091422_create_triggers_on_accounts.sql
@@ -1,0 +1,9 @@
+CREATE TRIGGER refresh_accounts_updated_at_step1
+    BEFORE UPDATE ON accounts FOR EACH ROW
+    EXECUTE PROCEDURE refresh_updated_at_step1();
+CREATE TRIGGER refresh_accounts_updated_at_step2
+    BEFORE UPDATE OF updated_at ON accounts FOR EACH ROW
+    EXECUTE PROCEDURE refresh_updated_at_step2();
+CREATE TRIGGER refresh_accounts_updated_at_step3
+    BEFORE UPDATE ON accounts FOR EACH ROW
+    EXECUTE PROCEDURE refresh_updated_at_step3();


### PR DESCRIPTION
# issueURL

https://github.com/nekochans/supabase-private-platform-example/issues/6

# この PR で対応する範囲 / この PR で対応しない範囲

Migrationの動作確認用にテーブルが1つ追加されている事。

# Storybook の URL、 スクリーンショット

UI変更はないのでなし

# 変更点概要

タイトルの通り。

テーブルの構造は `users` と同じ形の `accounts` とした。

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし